### PR TITLE
chore: bump deno, refresh deps, add integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,25 @@ jobs:
         with:
           deno-version: v2.x
       - run: deno fmt --check
-      - run: deno test
+      - name: Start redis
+        run: docker compose up -d redis
+      - name: Wait for redis
+        run: |
+          for i in {1..30}; do
+            if docker compose exec -T redis redis-cli ping | grep -q PONG; then
+              echo "Redis is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Redis failed to start" >&2
+          docker compose logs redis
+          exit 1
+      - name: Run tests
+        run: deno task test
+        env:
+          REDIS_URL: redis://localhost:6379
+      - if: always()
+        run: docker compose logs redis
+      - if: always()
+        run: docker compose down

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,63 @@
+{
+  "lsp": {
+    "deno": {
+      "settings": {
+        "deno": {
+          "enable": true,
+          "lint": true,
+          "unstable": true
+        }
+      }
+    }
+  },
+  "languages": {
+    "TypeScript": {
+      "language_servers": [
+        "deno",
+        "!typescript-language-server",
+        "!vtsls",
+        "!eslint"
+      ],
+      "formatter": "language_server",
+      "format_on_save": "on"
+    },
+    "TSX": {
+      "language_servers": [
+        "deno",
+        "!typescript-language-server",
+        "!vtsls",
+        "!eslint"
+      ],
+      "formatter": "language_server",
+      "format_on_save": "on"
+    },
+    "JavaScript": {
+      "language_servers": [
+        "deno",
+        "!typescript-language-server",
+        "!vtsls",
+        "!eslint"
+      ],
+      "formatter": "language_server",
+      "format_on_save": "on"
+    },
+    "JSX": {
+      "language_servers": [
+        "deno",
+        "!typescript-language-server",
+        "!vtsls",
+        "!eslint"
+      ],
+      "formatter": "language_server",
+      "format_on_save": "on"
+    },
+    "JSON": {
+      "formatter": "language_server",
+      "format_on_save": "on"
+    },
+    "JSONC": {
+      "formatter": "language_server",
+      "format_on_save": "on"
+    }
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:2.0.0
+FROM denoland/deno:2.7.14
 
 WORKDIR /app
 

--- a/deno.json
+++ b/deno.json
@@ -1,11 +1,13 @@
 {
   "tasks": {
-    "dev": "deno run --allow-env --allow-read --allow-net --watch src/main.ts"
+    "dev": "deno run --allow-env --allow-read --allow-net --watch src/main.ts",
+    "test": "deno test --allow-env --allow-read --allow-net --allow-sys"
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@^1.0.19",
     "@std/encoding": "jsr:@std/encoding@^1.0.10",
     "@std/encoding/": "jsr:/@std/encoding@^1.0.10/",
+    "@upstash/redis": "npm:@upstash/redis@^1",
     "hono": "npm:hono@^4.12.9",
     "hono/": "npm:/hono@^4.12.9/",
     "ioredis": "npm:ioredis@^5.9.2"

--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,12 @@
     "dev": "deno run --allow-env --allow-read --allow-net --watch src/main.ts"
   },
   "imports": {
-    "@std/assert": "jsr:@std/assert@1"
+    "@std/assert": "jsr:@std/assert@^1.0.19",
+    "@std/encoding": "jsr:@std/encoding@^1.0.10",
+    "@std/encoding/": "jsr:/@std/encoding@^1.0.10/",
+    "hono": "npm:hono@^4.12.9",
+    "hono/": "npm:/hono@^4.12.9/",
+    "ioredis": "npm:ioredis@^5.9.2"
   },
   "fmt": {
     "singleQuote": true

--- a/deno.lock
+++ b/deno.lock
@@ -5,6 +5,7 @@
     "jsr:@std/encoding@*": "1.0.10",
     "jsr:@std/encoding@^1.0.10": "1.0.10",
     "jsr:@std/internal@^1.0.12": "1.0.12",
+    "npm:@upstash/redis@1": "1.36.2",
     "npm:hono@*": "4.12.9",
     "npm:hono@^4.12.9": "4.12.9",
     "npm:ioredis@*": "5.9.2",
@@ -27,6 +28,12 @@
   "npm": {
     "@ioredis/commands@1.5.0": {
       "integrity": "sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow=="
+    },
+    "@upstash/redis@1.36.2": {
+      "integrity": "sha512-C0Yt8hc12vLaQYRG1fMci8iPrLtnTdbJG0HR5T8vKnvEP/1RdMMblsOJs5/jp0JXZJ1oSzMnQz4J9EVezNpI6A==",
+      "dependencies": [
+        "uncrypto"
+      ]
     },
     "cluster-key-slot@1.1.2": {
       "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="
@@ -77,12 +84,16 @@
     },
     "standard-as-callback@2.1.0": {
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
+    },
+    "uncrypto@0.1.3": {
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="
     }
   },
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@^1.0.19",
       "jsr:@std/encoding@^1.0.10",
+      "npm:@upstash/redis@1",
       "npm:hono@^4.12.9",
       "npm:ioredis@^5.9.2"
     ]

--- a/deno.lock
+++ b/deno.lock
@@ -1,42 +1,38 @@
 {
-  "version": "4",
+  "version": "5",
   "specifiers": {
-    "jsr:@std/assert@1": "1.0.6",
-    "jsr:@std/encoding@*": "1.0.5",
-    "jsr:@std/internal@^1.0.4": "1.0.4",
-    "npm:@types/node@*": "22.5.4",
-    "npm:hono@*": "4.6.4",
-    "npm:ioredis@*": "5.4.1"
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/encoding@*": "1.0.10",
+    "jsr:@std/encoding@^1.0.10": "1.0.10",
+    "jsr:@std/internal@^1.0.12": "1.0.12",
+    "npm:hono@*": "4.12.9",
+    "npm:hono@^4.12.9": "4.12.9",
+    "npm:ioredis@*": "5.9.2",
+    "npm:ioredis@^5.9.2": "5.9.2"
   },
   "jsr": {
-    "@std/assert@1.0.6": {
-      "integrity": "1904c05806a25d94fe791d6d883b685c9e2dcd60e4f9fc30f4fc5cf010c72207",
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
         "jsr:@std/internal"
       ]
     },
-    "@std/encoding@1.0.5": {
-      "integrity": "ecf363d4fc25bd85bd915ff6733a7e79b67e0e7806334af15f4645c569fefc04"
+    "@std/encoding@1.0.10": {
+      "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
     },
-    "@std/internal@1.0.4": {
-      "integrity": "62e8e4911527e5e4f307741a795c0b0a9e6958d0b3790716ae71ce085f755422"
+    "@std/internal@1.0.12": {
+      "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     }
   },
   "npm": {
-    "@ioredis/commands@1.2.0": {
-      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
-    },
-    "@types/node@22.5.4": {
-      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
-      "dependencies": [
-        "undici-types"
-      ]
+    "@ioredis/commands@1.5.0": {
+      "integrity": "sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow=="
     },
     "cluster-key-slot@1.1.2": {
       "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="
     },
-    "debug@4.3.7": {
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+    "debug@4.4.3": {
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dependencies": [
         "ms"
       ]
@@ -44,11 +40,11 @@
     "denque@2.1.0": {
       "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
     },
-    "hono@4.6.4": {
-      "integrity": "sha512-T5WqBkTOcIQblqBKB5mpzaH/A+dSpvVe938xZJCHOmOuYfF7DSwE/9/10+BMvwSPq9N/f6LiQ38HxrZSQOsXKw=="
+    "hono@4.12.9": {
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA=="
     },
-    "ioredis@5.4.1": {
-      "integrity": "sha512-2YZsvl7jopIa1gaePkeMtd9rAcSjOOjPtpcLlOeusyO+XH2SK5ZcT+UCrElPP+WVIInh2TzeI4XW9ENaSLVVHA==",
+    "ioredis@5.9.2": {
+      "integrity": "sha512-tAAg/72/VxOUW7RQSX1pIxJVucYKcjFjfvj60L57jrZpYCHC3XN0WCQ3sNYL4Gmvv+7GPvTAjc+KSdeNuE8oWQ==",
       "dependencies": [
         "@ioredis/commands",
         "cluster-key-slot",
@@ -81,14 +77,14 @@
     },
     "standard-as-callback@2.1.0": {
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
-    },
-    "undici-types@6.19.8": {
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     }
   },
   "workspace": {
     "dependencies": [
-      "jsr:@std/assert@1"
+      "jsr:@std/assert@^1.0.19",
+      "jsr:@std/encoding@^1.0.10",
+      "npm:hono@^4.12.9",
+      "npm:ioredis@^5.9.2"
     ]
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,45 @@
+import { Hono } from 'hono';
+import { bearerAuth } from 'hono/bearer-auth';
+import { logger } from 'hono/logger';
+
+import {
+  handleCommand,
+  handleCommandArray,
+  handleCommandTransactionArray,
+} from './lib/handle-command.ts';
+import { handler } from './lib/handler.ts';
+import { responseFactory } from './lib/response-factory.ts';
+
+export interface CreateAppOptions {
+  enableLogger?: boolean;
+}
+
+export function createApp(options: CreateAppOptions = {}): Hono {
+  const { enableLogger = true } = options;
+  const app = new Hono();
+
+  app.use(
+    '/*',
+    bearerAuth({
+      token: Deno.env.get('SR_TOKEN') || '',
+    }),
+  );
+
+  if (enableLogger) {
+    app.use(logger());
+  }
+
+  app.get('/', () =>
+    responseFactory({
+      status: 'ok',
+      result: 'Welcome to HTTP Redis!',
+    }));
+
+  app.get('/ping', (c) => c.text('Pong'));
+
+  app.post('/', handler(handleCommand));
+  app.post('/pipeline', handler(handleCommandArray));
+  app.post('/multi-exec', handler(handleCommandTransactionArray));
+
+  return app;
+}

--- a/src/lib/encode-result.ts
+++ b/src/lib/encode-result.ts
@@ -1,5 +1,5 @@
 import { isObject } from './utils/is-object.ts';
-import { encodeBase64 } from 'jsr:@std/encoding/base64';
+import { encodeBase64 } from '@std/encoding/base64';
 
 export function encodeResultValue(value: unknown): unknown {
   if (typeof value === 'number' || value === null) {

--- a/src/lib/handler.ts
+++ b/src/lib/handler.ts
@@ -1,4 +1,4 @@
-import type { Context } from 'npm:hono';
+import type { Context } from 'hono';
 
 import { encodeResponse } from './encode-result.ts';
 import { responseFactory } from './response-factory.ts';

--- a/src/lib/redis-client.ts
+++ b/src/lib/redis-client.ts
@@ -1,4 +1,4 @@
-import { Redis } from 'npm:ioredis';
+import { Redis } from 'ioredis';
 
 export class RedisClient {
   private redisClient: Redis | null = null;

--- a/src/lib/utils/is-encoding-enabled.ts
+++ b/src/lib/utils/is-encoding-enabled.ts
@@ -1,4 +1,4 @@
-import type { HonoRequest } from 'npm:hono';
+import type { HonoRequest } from 'hono';
 
 export function isEncodingEnabled(req: HonoRequest) {
   const encodingHeader = req.header('upstash-encoding');

--- a/src/lib/utils/is-object.ts
+++ b/src/lib/utils/is-object.ts
@@ -1,3 +1,3 @@
-export function isObject(obj: any) {
+export function isObject(obj: unknown) {
   return obj !== null && typeof obj === 'object' && !Array.isArray(obj);
 }

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,5 +1,0 @@
-import { assertEquals } from '@std/assert';
-
-Deno.test(function addTest() {
-  assertEquals(5, 5);
-});

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,37 +1,7 @@
-import { Hono } from 'hono';
-import { bearerAuth } from 'hono/bearer-auth';
-import { logger } from 'hono/logger';
-
-import {
-  handleCommand,
-  handleCommandArray,
-  handleCommandTransactionArray,
-} from './lib/handle-command.ts';
-import { handler } from './lib/handler.ts';
+import { createApp } from './app.ts';
 import { redisClient } from './lib/redis-client.ts';
-import { responseFactory } from './lib/response-factory.ts';
 
-const app = new Hono();
-
-app.use(
-  '/*',
-  bearerAuth({
-    token: Deno.env.get('SR_TOKEN') || '',
-  }),
-);
-app.use(logger());
-
-app.get('/', () =>
-  responseFactory({
-    status: 'ok',
-    result: 'Welcome to HTTP Redis!',
-  }));
-
-app.get('/ping', (c) => c.text('Pong'));
-
-app.post('/', handler(handleCommand));
-app.post('/pipeline', handler(handleCommandArray));
-app.post('/multi-exec', handler(handleCommandTransactionArray));
+const app = createApp();
 
 const server = Deno.serve(
   {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
-import { Hono } from 'npm:hono';
-import { bearerAuth } from 'npm:hono/bearer-auth';
-import { logger } from 'npm:hono/logger';
+import { Hono } from 'hono';
+import { bearerAuth } from 'hono/bearer-auth';
+import { logger } from 'hono/logger';
 
 import {
   handleCommand,

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,0 +1,78 @@
+import { Redis } from '@upstash/redis';
+
+import { createApp } from './app.ts';
+import { redisClient } from './lib/redis-client.ts';
+
+export interface TestServer {
+  url: string;
+  token: string;
+  redis: Redis;
+  server: Deno.HttpServer<Deno.NetAddr>;
+  close: () => Promise<void>;
+}
+
+export interface StartTestServerOptions {
+  token?: string;
+  enableAutoPipelining?: boolean;
+}
+
+export async function startTestServer(
+  options: StartTestServerOptions = {},
+): Promise<TestServer> {
+  const token = options.token ?? 'test-token';
+  Deno.env.set('SR_TOKEN', token);
+
+  const app = createApp({ enableLogger: false });
+
+  const server = Deno.serve({
+    port: 0,
+    hostname: '127.0.0.1',
+    onListen: () => {},
+  }, app.fetch);
+
+  const { port } = server.addr;
+  const url = `http://127.0.0.1:${port}`;
+
+  const redis = new Redis({
+    url,
+    token,
+    enableAutoPipelining: options.enableAutoPipelining ?? false,
+    enableTelemetry: false,
+  });
+
+  await redis.flushdb();
+
+  return {
+    url,
+    token,
+    redis,
+    server,
+    close: async () => {
+      await server.shutdown();
+    },
+  };
+}
+
+export function destroyBackendRedis(): void {
+  redisClient.destroyRedis();
+}
+
+export function testWithServer(
+  name: string,
+  fn: (ctx: TestServer) => Promise<void> | void,
+  options: StartTestServerOptions = {},
+): void {
+  Deno.test({
+    name,
+    sanitizeOps: false,
+    sanitizeResources: false,
+    fn: async () => {
+      const ctx = await startTestServer(options);
+      try {
+        await fn(ctx);
+      } finally {
+        await ctx.close();
+      }
+    },
+  });
+}

--- a/src/tests/auth.test.ts
+++ b/src/tests/auth.test.ts
@@ -1,0 +1,58 @@
+import { Redis } from '@upstash/redis';
+import { assertEquals, assertRejects } from '@std/assert';
+
+import { startTestServer } from '../test-utils.ts';
+
+Deno.test({
+  name: 'auth: rejects request with wrong token',
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const { url, close } = await startTestServer({ token: 'correct-token' });
+    try {
+      const wrong = new Redis({
+        url,
+        token: 'wrong-token',
+        enableAutoPipelining: false,
+        enableTelemetry: false,
+      });
+      await assertRejects(() => wrong.set('k', 'v'));
+    } finally {
+      await close();
+    }
+  },
+});
+
+Deno.test({
+  name: 'auth: rejects request without token',
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const { url, close } = await startTestServer({ token: 'correct-token' });
+    try {
+      const res = await fetch(`${url}/`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(['SET', 'k', 'v']),
+      });
+      assertEquals(res.status, 401);
+      await res.body?.cancel();
+    } finally {
+      await close();
+    }
+  },
+});
+
+Deno.test({
+  name: 'auth: accepts request with correct token',
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const { redis, close } = await startTestServer({ token: 'correct-token' });
+    try {
+      assertEquals(await redis.set('k', 'v'), 'OK');
+    } finally {
+      await close();
+    }
+  },
+});

--- a/src/tests/encoding.test.ts
+++ b/src/tests/encoding.test.ts
@@ -1,0 +1,66 @@
+import { Redis } from '@upstash/redis';
+import { assertEquals } from '@std/assert';
+
+import { startTestServer } from '../test-utils.ts';
+
+Deno.test({
+  name: 'encoding: client with base64 (default) round-trips strings',
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const { url, token, redis, close } = await startTestServer();
+    try {
+      const value = 'hello: world / spaces & symbols + base64?';
+      await redis.set('k', value);
+      assertEquals(await redis.get<string>('k'), value);
+
+      const raw = await fetch(`${url}/`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'authorization': `Bearer ${token}`,
+          'Upstash-Encoding': 'base64',
+        },
+        body: JSON.stringify(['GET', 'k']),
+      });
+      const body = await raw.json();
+      const decoded = atob(body.result);
+      assertEquals(decoded, value);
+    } finally {
+      await close();
+    }
+  },
+});
+
+Deno.test({
+  name: 'encoding: client without base64 returns plain strings',
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const { url, token, close } = await startTestServer();
+    try {
+      const plain = new Redis({
+        url,
+        token,
+        responseEncoding: false,
+        enableAutoPipelining: false,
+        enableTelemetry: false,
+      });
+      await plain.set('k', 'plain-text');
+      assertEquals(await plain.get<string>('k'), 'plain-text');
+
+      const raw = await fetch(`${url}/`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'authorization': `Bearer ${token}`,
+        },
+        body: JSON.stringify(['GET', 'k']),
+      });
+      const body = await raw.json();
+      assertEquals(body.result, 'plain-text');
+    } finally {
+      await close();
+    }
+  },
+});

--- a/src/tests/hash.test.ts
+++ b/src/tests/hash.test.ts
@@ -1,0 +1,56 @@
+import { assertEquals } from '@std/assert';
+
+import { testWithServer } from '../test-utils.ts';
+
+testWithServer('hash: hset/hget', async ({ redis }) => {
+  assertEquals(await redis.hset('h', { field1: 'value1' }), 1);
+  assertEquals(await redis.hget<string>('h', 'field1'), 'value1');
+  assertEquals(await redis.hget('h', 'missing'), null);
+});
+
+testWithServer('hash: hgetall', async ({ redis }) => {
+  await redis.hset('h', { a: 'alpha', b: 'beta', c: 'gamma' });
+  const all = await redis.hgetall<Record<string, string>>('h');
+  assertEquals(all, { a: 'alpha', b: 'beta', c: 'gamma' });
+});
+
+testWithServer('hash: hdel + hexists', async ({ redis }) => {
+  await redis.hset('h', { a: 'alpha', b: 'beta' });
+  assertEquals(await redis.hexists('h', 'a'), 1);
+  assertEquals(await redis.hdel('h', 'a'), 1);
+  assertEquals(await redis.hexists('h', 'a'), 0);
+});
+
+testWithServer('hash: hincrby', async ({ redis }) => {
+  await redis.hset('h', { counter: 10 });
+  assertEquals(await redis.hincrby('h', 'counter', 5), 15);
+  assertEquals(await redis.hincrby('h', 'counter', -3), 12);
+});
+
+testWithServer('hash: hkeys + hvals + hlen', async ({ redis }) => {
+  await redis.hset('h', { a: 'alpha', b: 'beta' });
+  const keys = (await redis.hkeys('h')).sort();
+  assertEquals(keys, ['a', 'b']);
+  const vals = ((await redis.hvals('h')) as string[]).sort();
+  assertEquals(vals, ['alpha', 'beta']);
+  assertEquals(await redis.hlen('h'), 2);
+});
+
+testWithServer('hash: hmget', async ({ redis }) => {
+  await redis.hset('h', { a: 'alpha', b: 'beta', c: 'gamma' });
+  assertEquals(await redis.hmget<Record<string, string>>('h', 'a', 'c'), {
+    a: 'alpha',
+    c: 'gamma',
+  });
+});
+
+testWithServer('hash: hsetnx', async ({ redis }) => {
+  assertEquals(await redis.hsetnx('h', 'f', 'first'), 1);
+  assertEquals(await redis.hsetnx('h', 'f', 'second'), 0);
+  assertEquals(await redis.hget<string>('h', 'f'), 'first');
+});
+
+testWithServer('hash: hincrbyfloat', async ({ redis }) => {
+  await redis.hset('h', { rate: '1.5' });
+  assertEquals(await redis.hincrbyfloat('h', 'rate', 0.5), 2);
+});

--- a/src/tests/keys.test.ts
+++ b/src/tests/keys.test.ts
@@ -1,0 +1,67 @@
+import { assertEquals } from '@std/assert';
+
+import { testWithServer } from '../test-utils.ts';
+
+testWithServer('keys: exists + del-multi', async ({ redis }) => {
+  await redis.set('a', '1');
+  await redis.set('b', '2');
+  assertEquals(await redis.exists('a', 'b', 'missing'), 2);
+  assertEquals(await redis.del('a', 'b'), 2);
+  assertEquals(await redis.exists('a'), 0);
+});
+
+testWithServer('keys: expire + ttl + persist', async ({ redis }) => {
+  await redis.set('k', 'v');
+  assertEquals(await redis.ttl('k'), -1);
+  assertEquals(await redis.expire('k', 60), 1);
+  const ttl = await redis.ttl('k');
+  assertEquals(ttl > 0 && ttl <= 60, true);
+  assertEquals(await redis.persist('k'), 1);
+  assertEquals(await redis.ttl('k'), -1);
+});
+
+testWithServer('keys: rename', async ({ redis }) => {
+  await redis.set('a', 'value');
+  assertEquals(await redis.rename('a', 'b'), 'OK');
+  assertEquals(await redis.get<string>('b'), 'value');
+  assertEquals(await redis.exists('a'), 0);
+});
+
+testWithServer('keys: type', async ({ redis }) => {
+  await redis.set('s', 'v');
+  await redis.lpush('l', 'x');
+  await redis.sadd('set', 'y');
+  await redis.hset('h', { f: 'v' });
+  assertEquals(await redis.type('s'), 'string');
+  assertEquals(await redis.type('l'), 'list');
+  assertEquals(await redis.type('set'), 'set');
+  assertEquals(await redis.type('h'), 'hash');
+  assertEquals(await redis.type('missing'), 'none');
+});
+
+testWithServer('keys: keys (pattern match)', async ({ redis }) => {
+  await redis.mset({ 'user:1': 'a', 'user:2': 'b', 'post:1': 'c' });
+  const users = (await redis.keys('user:*')).sort();
+  assertEquals(users, ['user:1', 'user:2']);
+});
+
+testWithServer('keys: scan', async ({ redis }) => {
+  await redis.mset({ k1: 'a', k2: 'b', k3: 'c' });
+  const collected: string[] = [];
+  let cursor: string | number = 0;
+  do {
+    const result: [string | number, string[]] = await redis.scan(cursor, {
+      count: 100,
+    });
+    collected.push(...result[1]);
+    cursor = result[0];
+  } while (cursor !== '0' && cursor !== 0);
+  assertEquals(collected.sort(), ['k1', 'k2', 'k3']);
+});
+
+testWithServer('keys: pexpire + pttl', async ({ redis }) => {
+  await redis.set('k', 'v');
+  assertEquals(await redis.pexpire('k', 60_000), 1);
+  const pttl = await redis.pttl('k');
+  assertEquals(pttl > 0 && pttl <= 60_000, true);
+});

--- a/src/tests/list.test.ts
+++ b/src/tests/list.test.ts
@@ -1,0 +1,47 @@
+import { assertEquals } from '@std/assert';
+
+import { testWithServer } from '../test-utils.ts';
+
+testWithServer('list: lpush/rpush/lrange', async ({ redis }) => {
+  assertEquals(await redis.rpush('l', 'a', 'b', 'c'), 3);
+  assertEquals(await redis.lpush('l', 'z'), 4);
+  assertEquals(await redis.lrange<string>('l', 0, -1), ['z', 'a', 'b', 'c']);
+});
+
+testWithServer('list: lpop/rpop', async ({ redis }) => {
+  await redis.rpush('l', 'a', 'b', 'c');
+  assertEquals(await redis.lpop<string>('l'), 'a');
+  assertEquals(await redis.rpop<string>('l'), 'c');
+  assertEquals(await redis.lrange<string>('l', 0, -1), ['b']);
+});
+
+testWithServer('list: llen + lindex', async ({ redis }) => {
+  await redis.rpush('l', 'a', 'b', 'c');
+  assertEquals(await redis.llen('l'), 3);
+  assertEquals(await redis.lindex('l', 0), 'a');
+  assertEquals(await redis.lindex('l', -1), 'c');
+});
+
+testWithServer('list: lset', async ({ redis }) => {
+  await redis.rpush('l', 'a', 'b', 'c');
+  assertEquals(await redis.lset('l', 1, 'B'), 'OK');
+  assertEquals(await redis.lrange<string>('l', 0, -1), ['a', 'B', 'c']);
+});
+
+testWithServer('list: lrem', async ({ redis }) => {
+  await redis.rpush('l', 'a', 'b', 'a', 'c', 'a');
+  assertEquals(await redis.lrem('l', 2, 'a'), 2);
+  assertEquals(await redis.lrange<string>('l', 0, -1), ['b', 'c', 'a']);
+});
+
+testWithServer('list: ltrim', async ({ redis }) => {
+  await redis.rpush('l', 'v0', 'v1', 'v2', 'v3', 'v4');
+  assertEquals(await redis.ltrim('l', 1, 3), 'OK');
+  assertEquals(await redis.lrange<string>('l', 0, -1), ['v1', 'v2', 'v3']);
+});
+
+testWithServer('list: linsert', async ({ redis }) => {
+  await redis.rpush('l', 'a', 'c');
+  assertEquals(await redis.linsert('l', 'before', 'c', 'b'), 3);
+  assertEquals(await redis.lrange<string>('l', 0, -1), ['a', 'b', 'c']);
+});

--- a/src/tests/multi-exec.test.ts
+++ b/src/tests/multi-exec.test.ts
@@ -1,0 +1,23 @@
+import { assertEquals } from '@std/assert';
+
+import { testWithServer } from '../test-utils.ts';
+
+testWithServer('multi-exec: basic transaction', async ({ redis }) => {
+  const tx = redis.multi();
+  tx.set('k', 'v');
+  tx.get('k');
+  tx.incr('counter');
+  tx.incr('counter');
+  const results = await tx.exec();
+  assertEquals(results, ['OK', 'v', 1, 2]);
+});
+
+testWithServer('multi-exec: hash + list mixed', async ({ redis }) => {
+  const tx = redis.multi();
+  tx.hset('h', { a: 'alpha' });
+  tx.hget('h', 'a');
+  tx.rpush('l', 'x', 'y');
+  tx.llen('l');
+  const results = await tx.exec();
+  assertEquals(results, [1, 'alpha', 2, 2]);
+});

--- a/src/tests/pipeline.test.ts
+++ b/src/tests/pipeline.test.ts
@@ -1,0 +1,32 @@
+import { assertEquals } from '@std/assert';
+
+import { testWithServer } from '../test-utils.ts';
+
+testWithServer('pipeline: mixed commands', async ({ redis }) => {
+  const p = redis.pipeline();
+  p.set('k1', 'v1');
+  p.set('k2', 'v2');
+  p.get('k1');
+  p.get('k2');
+  p.incr('counter');
+  p.incr('counter');
+  const results = await p.exec();
+  assertEquals(results, ['OK', 'OK', 'v1', 'v2', 1, 2]);
+});
+
+testWithServer('pipeline: empty exec is a no-op', async ({ redis }) => {
+  const p = redis.pipeline();
+  p.set('k', 'v');
+  const results = await p.exec();
+  assertEquals(results, ['OK']);
+  assertEquals(await redis.get<string>('k'), 'v');
+});
+
+testWithServer('pipeline: hash commands', async ({ redis }) => {
+  const p = redis.pipeline();
+  p.hset('h', { a: 'alpha', b: 'beta' });
+  p.hget('h', 'a');
+  p.hlen('h');
+  const results = await p.exec();
+  assertEquals(results, [2, 'alpha', 2]);
+});

--- a/src/tests/server.test.ts
+++ b/src/tests/server.test.ts
@@ -1,0 +1,31 @@
+import { assertEquals } from '@std/assert';
+
+import { testWithServer } from '../test-utils.ts';
+
+testWithServer('server: ping', async ({ redis }) => {
+  assertEquals(await redis.ping(), 'PONG');
+});
+
+testWithServer('server: echo', async ({ redis }) => {
+  assertEquals(await redis.echo('hello'), 'hello');
+});
+
+testWithServer('server: dbsize after writes', async ({ redis }) => {
+  await redis.mset({ a: '1', b: '2', c: '3' });
+  assertEquals(await redis.dbsize(), 3);
+});
+
+testWithServer('server: flushdb', async ({ redis }) => {
+  await redis.mset({ a: '1', b: '2' });
+  await redis.flushdb();
+  assertEquals(await redis.dbsize(), 0);
+});
+
+testWithServer('server: time', async ({ redis }) => {
+  const [seconds, micros] = await redis.time();
+  assertEquals(
+    typeof seconds === 'string' || typeof seconds === 'number',
+    true,
+  );
+  assertEquals(typeof micros === 'string' || typeof micros === 'number', true);
+});

--- a/src/tests/set.test.ts
+++ b/src/tests/set.test.ts
@@ -1,0 +1,53 @@
+import { assertEquals } from '@std/assert';
+
+import { testWithServer } from '../test-utils.ts';
+
+testWithServer('set: sadd/smembers/scard', async ({ redis }) => {
+  assertEquals(await redis.sadd('s', 'a', 'b', 'c'), 3);
+  const members = (await redis.smembers<string[]>('s')).sort();
+  assertEquals(members, ['a', 'b', 'c']);
+  assertEquals(await redis.scard('s'), 3);
+});
+
+testWithServer('set: srem + sismember', async ({ redis }) => {
+  await redis.sadd('s', 'a', 'b', 'c');
+  assertEquals(await redis.sismember('s', 'a'), 1);
+  assertEquals(await redis.srem('s', 'a'), 1);
+  assertEquals(await redis.sismember('s', 'a'), 0);
+});
+
+testWithServer('set: sinter/sunion/sdiff', async ({ redis }) => {
+  await redis.sadd('a', 'x', 'y', 'z');
+  await redis.sadd('b', 'y', 'z', 'w');
+  assertEquals(((await redis.sinter('a', 'b')) as string[]).sort(), [
+    'y',
+    'z',
+  ]);
+  assertEquals(((await redis.sunion('a', 'b')) as string[]).sort(), [
+    'w',
+    'x',
+    'y',
+    'z',
+  ]);
+  assertEquals(await redis.sdiff('a', 'b'), ['x']);
+});
+
+testWithServer('set: spop', async ({ redis }) => {
+  await redis.sadd('s', 'only');
+  assertEquals(await redis.spop<string>('s'), 'only');
+  assertEquals(await redis.scard('s'), 0);
+});
+
+testWithServer('set: srandmember', async ({ redis }) => {
+  await redis.sadd('s', 'a', 'b', 'c');
+  const member = await redis.srandmember<string>('s');
+  assertEquals(['a', 'b', 'c'].includes(member as string), true);
+});
+
+testWithServer('set: smove', async ({ redis }) => {
+  await redis.sadd('src', 'x', 'y');
+  await redis.sadd('dst', 'z');
+  assertEquals(await redis.smove('src', 'dst', 'x'), 1);
+  assertEquals((await redis.smembers<string[]>('src')).sort(), ['y']);
+  assertEquals((await redis.smembers<string[]>('dst')).sort(), ['x', 'z']);
+});

--- a/src/tests/strings.test.ts
+++ b/src/tests/strings.test.ts
@@ -1,0 +1,64 @@
+import { assertEquals } from '@std/assert';
+
+import { testWithServer } from '../test-utils.ts';
+
+testWithServer('strings: set/get/del', async ({ redis }) => {
+  assertEquals(await redis.set('k', 'v'), 'OK');
+  assertEquals(await redis.get<string>('k'), 'v');
+  assertEquals(await redis.del('k'), 1);
+  assertEquals(await redis.get('k'), null);
+});
+
+testWithServer('strings: incr/decr/incrby/decrby', async ({ redis }) => {
+  assertEquals(await redis.incr('counter'), 1);
+  assertEquals(await redis.incr('counter'), 2);
+  assertEquals(await redis.incrby('counter', 5), 7);
+  assertEquals(await redis.decr('counter'), 6);
+  assertEquals(await redis.decrby('counter', 3), 3);
+});
+
+testWithServer('strings: append + strlen', async ({ redis }) => {
+  assertEquals(await redis.append('k', 'hello'), 5);
+  assertEquals(await redis.append('k', '-world'), 11);
+  assertEquals(await redis.strlen('k'), 11);
+  assertEquals(await redis.get<string>('k'), 'hello-world');
+});
+
+testWithServer('strings: getrange + setrange', async ({ redis }) => {
+  await redis.set('k', 'hello world');
+  assertEquals(await redis.getrange('k', 0, 4), 'hello');
+  assertEquals(await redis.setrange('k', 6, 'there'), 11);
+  assertEquals(await redis.get<string>('k'), 'hello there');
+});
+
+testWithServer('strings: mset + mget', async ({ redis }) => {
+  await redis.mset({ a: 'alpha', b: 'beta', c: 'gamma' });
+  assertEquals(await redis.mget<string[]>('a', 'b', 'c'), [
+    'alpha',
+    'beta',
+    'gamma',
+  ]);
+  assertEquals(await redis.mget<(string | null)[]>('a', 'missing', 'c'), [
+    'alpha',
+    null,
+    'gamma',
+  ]);
+});
+
+testWithServer('strings: setex + ttl', async ({ redis }) => {
+  await redis.setex('k', 60, 'v');
+  assertEquals(await redis.get<string>('k'), 'v');
+  const ttl = await redis.ttl('k');
+  assertEquals(ttl > 0 && ttl <= 60, true);
+});
+
+testWithServer('strings: getset', async ({ redis }) => {
+  await redis.set('k', 'old');
+  assertEquals(await redis.getset('k', 'new'), 'old');
+  assertEquals(await redis.get<string>('k'), 'new');
+});
+
+testWithServer('strings: incrbyfloat', async ({ redis }) => {
+  await redis.set('k', '10.5');
+  assertEquals(await redis.incrbyfloat('k', 0.5), 11);
+});

--- a/src/tests/zset.test.ts
+++ b/src/tests/zset.test.ts
@@ -1,0 +1,71 @@
+import { assertEquals } from '@std/assert';
+
+import { testWithServer } from '../test-utils.ts';
+
+testWithServer('zset: zadd + zcard + zscore', async ({ redis }) => {
+  assertEquals(
+    await redis.zadd('z', { score: 1, member: 'a' }, { score: 2, member: 'b' }),
+    2,
+  );
+  assertEquals(await redis.zcard('z'), 2);
+  assertEquals(await redis.zscore('z', 'a'), 1);
+});
+
+testWithServer('zset: zrange', async ({ redis }) => {
+  await redis.zadd(
+    'z',
+    { score: 1, member: 'a' },
+    { score: 2, member: 'b' },
+    { score: 3, member: 'c' },
+  );
+  assertEquals(await redis.zrange<string[]>('z', 0, -1), ['a', 'b', 'c']);
+  assertEquals(await redis.zrange<string[]>('z', 0, -1, { rev: true }), [
+    'c',
+    'b',
+    'a',
+  ]);
+});
+
+testWithServer('zset: zrangebyscore', async ({ redis }) => {
+  await redis.zadd(
+    'z',
+    { score: 1, member: 'a' },
+    { score: 5, member: 'b' },
+    { score: 10, member: 'c' },
+  );
+  assertEquals(await redis.zrange<string[]>('z', 2, 8, { byScore: true }), [
+    'b',
+  ]);
+});
+
+testWithServer('zset: zrem', async ({ redis }) => {
+  await redis.zadd('z', { score: 1, member: 'a' }, { score: 2, member: 'b' });
+  assertEquals(await redis.zrem('z', 'a'), 1);
+  assertEquals(await redis.zcard('z'), 1);
+});
+
+testWithServer('zset: zincrby', async ({ redis }) => {
+  await redis.zadd('z', { score: 1, member: 'a' });
+  assertEquals(await redis.zincrby('z', 4, 'a'), 5);
+});
+
+testWithServer('zset: zrank + zrevrank', async ({ redis }) => {
+  await redis.zadd(
+    'z',
+    { score: 1, member: 'a' },
+    { score: 2, member: 'b' },
+    { score: 3, member: 'c' },
+  );
+  assertEquals(await redis.zrank('z', 'a'), 0);
+  assertEquals(await redis.zrevrank('z', 'a'), 2);
+});
+
+testWithServer('zset: zcount', async ({ redis }) => {
+  await redis.zadd(
+    'z',
+    { score: 1, member: 'a' },
+    { score: 5, member: 'b' },
+    { score: 10, member: 'c' },
+  );
+  assertEquals(await redis.zcount('z', 1, 5), 2);
+});


### PR DESCRIPTION
## Summary
- Bump Deno runtime to 2.7.14 and refresh dependencies (hono 4.6.4 → 4.12.9, ioredis 5.4.1 → 5.9.2, @std/* to latest).
- Move all package specifiers into `deno.json` imports map; drop `npm:`/`jsr:` prefixes from source files.
- Add integration test suite (58 tests) that runs the official `@upstash/redis` client against the server, covering string/hash/list/set/zset/keys/server commands plus pipeline, multi-exec, auth, and base64 encoding paths.
- Extract `createApp()` into `src/app.ts` so tests can boot the server in-process; `src/main.ts` becomes a thin entrypoint.
- CI: bring up Redis via `docker compose` before `deno task test`.
- Add `.zed/settings.json` so Zed picks Deno LSP instead of vtsls for this project.

## Test plan
- [x] `docker compose up -d redis && deno task test` — 58/58 pass locally
- [x] `deno fmt --check` clean
- [x] `docker compose build` + `docker compose up -d` — server boots, `/ping`, `POST /`, `POST /pipeline` respond correctly with the configured `SR_TOKEN`
- [ ] CI on this PR is green