### PR TITLE
feat: lazy redis connect with optional idle disconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,19 @@ provides Redis.
 - Simple setup and high performance thanks to Hono.
 - Easy to deploy on Railway.
 - Compatible with Upstash, a cloud service that provides Redis.
+
+### Environment variables:
+
+- `REDIS_URL` — connection string to the Redis instance (defaults to `redis://localhost:6379`).
+- `SR_TOKEN` — bearer token required by clients.
+- `PORT` / `HOST` — HTTP server bind address (default `0.0.0.0:3000`).
+- `SR_IDLE_TIMEOUT_MS` — idle timeout for the Redis connection in milliseconds.
+  Defaults to `0` (the connection is kept open for the lifetime of the process,
+  matching the previous behaviour). Any value greater than `0` will close the
+  Redis connection after that many milliseconds of inactivity and re-open it on
+  the next request.
+
+  Useful for platforms like [Railway serverless](https://docs.railway.com/deployments/serverless),
+  where an active outbound TCP connection (e.g. to Redis) prevents the service
+  from being put to sleep. Note that every reconnect pays the TCP/TLS/AUTH
+  handshake cost, so pick a value that fits your traffic profile.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ provides Redis.
 
 ### Environment variables:
 
-- `REDIS_URL` — connection string to the Redis instance (defaults to `redis://localhost:6379`).
+- `REDIS_URL` — connection string to the Redis instance (defaults to
+  `redis://localhost:6379`).
 - `SR_TOKEN` — bearer token required by clients.
 - `PORT` / `HOST` — HTTP server bind address (default `0.0.0.0:3000`).
 - `SR_IDLE_TIMEOUT_MS` — idle timeout for the Redis connection in milliseconds.
@@ -29,7 +30,8 @@ provides Redis.
   Redis connection after that many milliseconds of inactivity and re-open it on
   the next request.
 
-  Useful for platforms like [Railway serverless](https://docs.railway.com/deployments/serverless),
-  where an active outbound TCP connection (e.g. to Redis) prevents the service
-  from being put to sleep. Note that every reconnect pays the TCP/TLS/AUTH
-  handshake cost, so pick a value that fits your traffic profile.
+  Useful for platforms like
+  [Railway serverless](https://docs.railway.com/deployments/serverless), where
+  an active outbound TCP connection (e.g. to Redis) prevents the service from
+  being put to sleep. Note that every reconnect pays the TCP/TLS/AUTH handshake
+  cost, so pick a value that fits your traffic profile.

--- a/src/lib/redis-client.ts
+++ b/src/lib/redis-client.ts
@@ -2,42 +2,72 @@ import { Redis } from 'ioredis';
 
 export class RedisClient {
   private redisClient: Redis | null = null;
+  private idleTimer: number | null = null;
+  private readonly redisUrl: string;
+  private readonly enableSSL: boolean;
+  private readonly idleTimeoutMs: number;
 
   constructor() {
-    const redisUrl = Deno.env.get('REDIS_URL') || 'redis://localhost:6379';
-    const enableSSL = redisUrl.startsWith('rediss://');
+    this.redisUrl = Deno.env.get('REDIS_URL') || 'redis://localhost:6379';
+    this.enableSSL = this.redisUrl.startsWith('rediss://');
+    this.idleTimeoutMs = Number(Deno.env.get('SR_IDLE_TIMEOUT_MS')) || 0;
+  }
 
-    const redisClient = (this.redisClient = new Redis(redisUrl, {
-      tls: enableSSL ? { rejectUnauthorized: false } : undefined,
-    }));
+  private ensureConnected(): Redis {
+    if (this.redisClient) {
+      return this.redisClient;
+    }
 
-    this.redisClient.on('error', (error) => {
-      console.error('Redis connection error:', error);
-      this.redisClient = null;
+    const redisClient = new Redis(this.redisUrl, {
+      lazyConnect: true,
+      tls: this.enableSSL ? { rejectUnauthorized: false } : undefined,
     });
 
-    this.redisClient.on('connect', () => {
-      this.redisClient = redisClient;
+    redisClient.on('error', (error) => {
+      console.error('Redis connection error:', error);
+    });
+
+    redisClient.on('connect', () => {
       console.log('Redis connected');
     });
+
+    this.redisClient = redisClient;
+    return redisClient;
+  }
+
+  private resetIdleTimer(): void {
+    if (this.idleTimer !== null) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
+
+    if (this.idleTimeoutMs > 0 && this.redisClient) {
+      this.idleTimer = setTimeout(() => {
+        this.destroyRedis();
+      }, this.idleTimeoutMs);
+    }
   }
 
   async redisCommand(commandArray: string[]): Promise<any> {
-    if (!this.redisClient) {
-      throw new Error('Redis client is not connected');
-    }
+    const client = this.ensureConnected();
 
     try {
       const [command, ...args] = commandArray;
 
-      const result = await this.redisClient.call(command, args);
+      const result = await client.call(command, args);
       return { status: 'ok', result };
     } catch (error) {
       return { status: 'error', error: (error as any).message };
+    } finally {
+      this.resetIdleTimer();
     }
   }
 
   destroyRedis() {
+    if (this.idleTimer !== null) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
     if (this.redisClient) {
       this.redisClient.disconnect();
       this.redisClient = null;


### PR DESCRIPTION
Closes #7.

## Summary
- Enables Railway [serverless / sleep mode](https://docs.railway.com/deployments/serverless) by allowing the outbound Redis connection to be torn down after a configurable idle period — an always-on TCP connection to Redis is what previously kept the service from sleeping.
- New env var `SR_IDLE_TIMEOUT_MS`:
  - default `0` — connection is kept open for the lifetime of the process (matches current behaviour, no surprise for existing deployments);
  - any value `> 0` — Redis client is disconnected after that many ms of inactivity and lazily re-created on the next request.
- Uses ioredis `lazyConnect: true`, so even at startup no socket is opened until the first HTTP request.

## Test plan
- [x] `deno task test` — 58/58 passing.
- [x] Ad-hoc sanity test verified:
  - no eager connect on module import;
  - with `SR_IDLE_TIMEOUT_MS=200` the connection is closed after idle;
  - the next command transparently re-establishes the connection.
- [ ] Reviewer: deploy to a Railway service with sleep mode enabled and confirm the service can now go to sleep when idle.